### PR TITLE
Peer filters

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,5 @@
 CompileFlags:
   Add: [-xc]
+
+Diagnostics:
+  UnusedIncludes: None

--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ an interface section are optional.
     filter list being a deny list, or vice versa.
 * Outbound interface filters are applied prior to sending packets to
     the interface.
+* There is a special filter list called the "deny all" filter list, which
+    matches and block all services. The format of the deny all filter
+    is a list with a single element, "`<all>`". This filter list may only
+    be specified as a parameter to a deny property (`deny-inbound-filters`,
+    `deny-outbound-filters`, `peer-deny-outbound-filters`).
+
 * The default behavior is to allow all names inbound and outbound.
 
 ---

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ configuration file.
 ```
 [global]
   # The list of interfaces (mandatory).
-  interfaces = ix0, igc0
+  interfaces = ix0, igc0, igc1
 
   # Optionally Disable ipv4.
   disable-ipv4 = no
@@ -189,17 +189,21 @@ an interface section are optional.
   # An optional list of filters to allow inbound
   allow-inbound-filters = _ipp, _ipps, _airplay
 
-  # An option list of filters to deny outbound
+  # An optional list of filters to deny outbound
   deny-outbound-filters = _ssh
 
+  # An optional list of filters to allow outbound
+  # for packets from a specific peer
+  peer-allow-outbound-filters = igc0, _ipp, _ipps
+  peer-deny-outbound-filters = igc1, _airplay
 ```
 
 #### The following properties may be defined in interface sections:
 
 * `disable-ipv4`: This allows IPv4 to be disabled for this interface.
-   Valid values are `yes` or `no`. The default is `no`.
+    Valid values are `yes` or `no`. The default is `no`.
 * `disable-ipv6`: This allows IPv6 to be disabled for this interface.
-   Valid values are `yes` or `no`. The default is `no`.
+    Valid values are `yes` or `no`. The default is `no`.
 * `allow-inbound-filters`: If defined, any names that do not match one of
     the filters in the list will be discarded from incoming packets on
     this interface. The default is to allow all names.
@@ -211,20 +215,44 @@ an interface section are optional.
     this interface. The default is to allow all names.
 * `deny-outbound-filters`: If defined, any names that match one of the
     filters in the list will be discarded from outgoing packets on this
-    interfaces. There is no default.
+    interface. There is no default.
+* `peer-allow-outbound-filters`:
+    If defined, this creates an outbound allow filter list for this
+    interface that applies to packets that originate from a specific peer
+    interface. The value of this parameter is a comma separated
+    list with the first element being the name of the peer interface,
+    followed by the list of filters. Any names from the peer interface
+    that do not match one of the filters in the list will be discarded
+    from outgoing packets on this interface.
+* `peer-deny-outbound-filters`: If defined, this creates an outbound
+    deny filter list for this interface that applies to packets that
+    originate from a specific peer interface. The value of
+    this parameter is a comma separated list with the first element
+    being the name of the peer interface, followed by the list of filters.
+    Any names from the peer interface that do not match one of the filters
+    in the list will be discarded from outgoing packets on this interface.
 
 ##### Notes:
 * The parameter to enable or disable IPv4/IPv6 cannot override the global
     setting. I.E. if the global setting is `disable-ipv6 = yes`, an
     interface may not specify `disable-ipv6 = no`.
-* Only one inbound filter list may be provided per interface. Either an
-    allow list, or a deny list, but not both.
-* Only one outbound filter list may be provided per interface. Either an
-    allow list, or a deny list, but not both.
-* Inbound interface filters are applied following the global filters. An
-    inbound interface filter does not override the global filter list.
-* Outbound interface filters are applied prior to sending packets to the
+* Only one inbound filter list may be provided. Either an allow list,
+    or a deny list, but not both.
+* Inbound interface filters are applied following the global filters.
+    An inbound interface filter does not override the global filter list.
+* Only one interface wide outbound filter list may be provided. Either
+    an allow list, or a deny list, but not both.
+* Only one peer specific outbound filter list may be provided per peer
+    interface. Either an allow list, or a deny list, but not both.
+* A peer specific outbound filter list overrides an interface wide
+    outbound filter list for packets that originate from the peer
     interface.
+* If both interface wide and peer specific outbound filter lists are
+    defined, the allow/deny types do not need to match. I.E. a peer
+    specific filter list can be an allow list, with the interface wide
+    filter list being a deny list, or vice versa.
+* Outbound interface filters are applied prior to sending packets to
+    the interface.
 * The default behavior is to allow all names inbound and outbound.
 
 ---

--- a/bridge.c
+++ b/bridge.c
@@ -126,7 +126,7 @@ static void receive(
     }
 
     dest_filter_list = interface->dest_filter_list[ip_type];
-    for (dest_filter_index = 0; dest_filter_index < interface->dest_filter_count[IPV4]; dest_filter_index++)
+    for (dest_filter_index = 0; dest_filter_index < interface->dest_filter_count[ip_type]; dest_filter_index++)
     {
         dest_filter = dest_filter_list[dest_filter_index];
 

--- a/bridge.c
+++ b/bridge.c
@@ -83,7 +83,6 @@ typedef struct
 } thread_local_storage_t;
 
 
-
 //
 // Process an incoming packet
 //
@@ -96,10 +95,11 @@ static void receive(
     ssize_t                     bytes;
     socket_address_t *          dst_addr = &local_storage->dst_addr;
     socklen_t                   dst_addr_len = local_storage->dst_addr_len;
+    dest_filter_list_t **       dest_filter_list;
+    dest_filter_list_t *        dest_filter;
     interface_t *               peer;
+    unsigned int                dest_filter_index;
     unsigned int                peer_index;
-    unsigned int                filter_index;
-    filter_list_t *             filter_list;
     unsigned int                r;
 
     // Receive the packet
@@ -125,73 +125,42 @@ static void receive(
         }
     }
 
-    // Forward the packet to peers that do not have outbound filters
-    if (interface->peer_nofilter_count[ip_type])
+    dest_filter_list = interface->dest_filter_list[ip_type];
+    for (dest_filter_index = 0; dest_filter_index < interface->dest_filter_count[IPV4]; dest_filter_index++)
     {
-        if (filtering_enabled && dns_src_filter_active(local_storage->dns_state))
+        dest_filter = dest_filter_list[dest_filter_index];
+
+        // Does the packet need to be re-encoded?
+        if (filtering_enabled && (dest_filter->filter || dns_src_filter_active(local_storage->dns_state)))
         {
-            r = dns_encode_packet(local_storage->dns_state, &local_storage->recv_packet, &local_storage->send_packet, NULL);
-            if (r == 0)
-            {
-                // If the encoder failed, drop the packet
-                return;
-            }
             packet = &local_storage->send_packet;
-        }
-
-        for (peer_index = 0; peer_index < interface->peer_count[ip_type]; peer_index++)
-        {
-            peer = interface->peer_list[ip_type][peer_index];
-            if (peer->outbound_filter_list == NULL)
-            {
-                if (ip_type == IPV6)
-                {
-                    // Set the destination scope ID
-                    dst_addr->sin6.sin6_scope_id = peer->if_index;
-                }
-
-                bytes = sendto(peer->sock[ip_type], packet->buffer, packet->bytes, 0, &dst_addr->sa, dst_addr_len);
-                if (bytes == -1 && errno != ENETDOWN)
-                {
-                    logger("sendto error on interface %s: %s\n", peer->name, strerror(errno));
-                }
-            }
-        }
-    }
-
-    // Forward the packet to peers that do have outbound filters
-    if (interface->peer_filter_count[ip_type])
-    {
-        packet = &local_storage->send_packet;
-
-        for (filter_index = 0; filter_index < interface->peer_filter_count[ip_type]; filter_index++)
-        {
-            filter_list = interface->peer_filter_list[ip_type][filter_index];
-
-            r = dns_encode_packet(local_storage->dns_state, &local_storage->recv_packet, &local_storage->send_packet, filter_list);
+            r = dns_encode_packet(local_storage->dns_state, &local_storage->recv_packet, packet, dest_filter->filter);
             if (r == 0)
             {
                 // If everything has been filtered, skip the packet
                 continue;
             }
+        }
+        else
+        {
+            packet = &local_storage->recv_packet;
+        }
 
-            for (peer_index = 0; peer_index < interface->peer_count[ip_type]; peer_index++)
+        // Send the packet to each of the peers
+        for (peer_index = 0; peer_index < dest_filter->peer_count; peer_index++)
+        {
+            peer = dest_filter->peer_list[peer_index];
+
+            if (ip_type == IPV6)
             {
-                peer = interface->peer_list[ip_type][peer_index];
-                if (peer->outbound_filter_list == filter_list)
-                {
-                    if (ip_type == IPV6)
-                    {
-                        // Set the destination scope ID
-                        dst_addr->sin6.sin6_scope_id = peer->if_index;
-                    }
+                // Set the destination scope ID
+                dst_addr->sin6.sin6_scope_id = peer->if_index;
+            }
 
-                    bytes = sendto(peer->sock[ip_type], packet->buffer, packet->bytes, 0, &dst_addr->sa, dst_addr_len);
-                    if (bytes == -1 && errno != ENETDOWN)
-                    {
-                        logger("sendto error on interface %s: %s\n", peer->name, strerror(errno));
-                    }
-                }
+            bytes = sendto(peer->sock[ip_type], packet->buffer, packet->bytes, 0, &dst_addr->sa, dst_addr_len);
+            if (bytes == -1 && errno != ENETDOWN)
+            {
+                logger("sendto error on interface %s: %s\n", peer->name, strerror(errno));
             }
         }
     }

--- a/bridge.c
+++ b/bridge.c
@@ -36,6 +36,7 @@
 #include <pthread.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <netdb.h>
 
 #include "common.h"
 #include "socketp.h"
@@ -111,7 +112,7 @@ static void receive(
     unsigned int                r;
 
     // Receive the packet
-    local_storage->recv_msg.msg_namelen = sizeof(local_storage->recv_packet.src_addr);
+    local_storage->recv_msg.msg_namelen = sizeof(packet->src_addr);
     bytes = recvmsg(interface->sock[ip_type], &local_storage->recv_msg, 0);
     if (bytes == -1)
     {
@@ -119,10 +120,7 @@ static void receive(
         return;
     }
     packet->bytes = bytes;
-
-    // Save the source address for the received message
     packet->src_addr_len = local_storage->recv_msg.msg_namelen;
-    memcpy(&packet->src_addr, local_storage->recv_msg.msg_name, packet->src_addr_len);
 
 #if defined(HAVE_IP_RECVIF)
     {

--- a/bridge.c
+++ b/bridge.c
@@ -38,6 +38,7 @@
 #include <arpa/inet.h>
 
 #include "common.h"
+#include "socketp.h"
 
 
 //
@@ -80,6 +81,13 @@ typedef struct
     // Receive and send packets
     packet_t                    recv_packet;
     packet_t                    send_packet;
+
+    // Structures for recvmsg
+    struct msghdr               recv_msg;
+    struct iovec                recv_iovec;
+#if defined(HAVE_IP_RECVIF)
+    char                        cmsg_buf[CMSG_SPACE(sizeof(socket_address_t))];
+#endif
 } thread_local_storage_t;
 
 
@@ -103,16 +111,56 @@ static void receive(
     unsigned int                r;
 
     // Receive the packet
-    packet->src_addr_len = sizeof(packet->src_addr.storage);
-    bytes = recvfrom(interface->sock[ip_type],
-                            packet->buffer, sizeof(packet->buffer), 0,
-                            &packet->src_addr.sa, &packet->src_addr_len);
+    local_storage->recv_msg.msg_namelen = sizeof(local_storage->recv_packet.src_addr);
+    bytes = recvmsg(interface->sock[ip_type], &local_storage->recv_msg, 0);
     if (bytes == -1)
     {
-        logger("recvfrom error on interface %s: %s\n", interface->name, strerror(errno));
+        logger("recvmsg error on interface %s: %s\n", interface->name, strerror(errno));
         return;
     }
     packet->bytes = bytes;
+
+    // Save the source address for the received message
+    packet->src_addr_len = local_storage->recv_msg.msg_namelen;
+    memcpy(&packet->src_addr, local_storage->recv_msg.msg_name, packet->src_addr_len);
+
+#if defined(HAVE_IP_RECVIF)
+    {
+        struct cmsghdr *        cmsg;
+        struct sockaddr_dl *    sa_dl;
+        interface_t *           new_interface = NULL;
+        unsigned int            index;
+
+        for (cmsg = CMSG_FIRSTHDR(&local_storage->recv_msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&local_storage->recv_msg, cmsg))
+        {
+            if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_RECVIF)
+            {
+                sa_dl = (struct sockaddr_dl *) CMSG_DATA(cmsg);
+                if (interface->if_index != sa_dl->sdl_index)
+                {
+                    // Look for the correct interface by system interface index
+                    for (index = 0; index < local_storage->interface_count; index++)
+                    {
+                        if (local_storage->interface_list[index]->if_index == sa_dl->sdl_index)
+                        {
+                            new_interface = local_storage->interface_list[index];
+                            break;
+                        }
+                    }
+
+                    // If no interface is found, skip this message
+                    if (new_interface == NULL)
+                    {
+                        return;
+                    }
+
+                    // Assign the correct interface to the packet
+                    interface = new_interface;
+                }
+            }
+        }
+    }
+#endif
 
     // If filter is enabled, decode the packet
     if (filtering_enabled)
@@ -133,13 +181,13 @@ static void receive(
         // Does the packet need to be re-encoded?
         if (filtering_enabled && (dest_filter->filter || dns_src_filter_active(local_storage->dns_state)))
         {
-            packet = &local_storage->send_packet;
-            r = dns_encode_packet(local_storage->dns_state, &local_storage->recv_packet, packet, dest_filter->filter);
+            r = dns_encode_packet(local_storage->dns_state, &local_storage->recv_packet, &local_storage->send_packet, dest_filter->filter);
             if (r == 0)
             {
                 // If everything has been filtered, skip the packet
                 continue;
             }
+            packet = &local_storage->send_packet;
         }
         else
         {
@@ -302,6 +350,18 @@ static thread_local_storage_t * local_storage_create(
     {
         fatal("Cannot allocate memory: %s\n", strerror(errno));
     }
+
+    // Initialize recvmsg structures
+    local_storage->recv_msg.msg_name = &local_storage->recv_packet.src_addr;
+    local_storage->recv_msg.msg_namelen = sizeof(local_storage->recv_packet.src_addr);
+    local_storage->recv_msg.msg_iov = &local_storage->recv_iovec;
+    local_storage->recv_msg.msg_iovlen = 1;
+    local_storage->recv_iovec.iov_base = local_storage->recv_packet.buffer;
+    local_storage->recv_iovec.iov_len = sizeof(local_storage->recv_packet.buffer);
+#if defined(HAVE_IP_RECVIF)
+    local_storage->recv_msg.msg_control = local_storage->cmsg_buf;
+    local_storage->recv_msg.msg_controllen = sizeof(local_storage->cmsg_buf);
+#endif
 
     // DNS state for the thread
     local_storage->dns_state = dns_state_create();

--- a/common.h
+++ b/common.h
@@ -104,7 +104,8 @@ typedef struct
 typedef enum
 {
     ALLOW                       = 0,
-    DENY                        = 1
+    DENY                        = 1,
+    DENY_ALL                    = 2
 } filter_allow_deny_t;
 
 typedef struct

--- a/common.h
+++ b/common.h
@@ -224,20 +224,20 @@ extern void os_initialize_sockets(void);
 
 
 // Set the global filter list
-extern unsigned int set_global_filter_list(
+extern void set_global_filter_list(
     const filter_allow_deny_t   allow_deny,
     char **                     list,
     unsigned int                count);
 
 // Set an interface inbound filter list
-extern unsigned int set_interface_inbound_filter_list(
+extern void set_interface_inbound_filter_list(
     interface_t *               interface,
     filter_allow_deny_t         allow_deny,
     char **                     list,
     unsigned int                count);
 
 // Set an interface outbound filter list
-extern unsigned int set_interface_outbound_filter_list(
+extern void set_interface_outbound_filter_list(
     interface_t *               interface,
     filter_allow_deny_t         allow_deny,
     char **                     list,

--- a/common.h
+++ b/common.h
@@ -123,12 +123,23 @@ typedef enum
 } ip_type_t;
 #define NUM_IP_TYPES            2
 
+// Destination filter list structure
+typedef struct dest_filter_list
+{
+    filter_list_t *             filter;
+    unsigned int                peer_count;
+    struct interface *          peer_list[];
+} dest_filter_list_t;
+
 // Interface structure
 typedef struct interface
 {
     const char *                name;
+    unsigned int                index;
+
     filter_list_t *             inbound_filter_list;
     filter_list_t *             outbound_filter_list;
+    filter_list_t **            peer_outbound_filter_list;
 
     unsigned int                if_index;
     unsigned int                disable_ip[NUM_IP_TYPES];
@@ -140,11 +151,8 @@ typedef struct interface
 
     int                         sock[NUM_IP_TYPES];
 
-    struct interface **         peer_list[NUM_IP_TYPES];
-    unsigned int                peer_count[NUM_IP_TYPES];
-    filter_list_t **            peer_filter_list[NUM_IP_TYPES];
-    unsigned int                peer_filter_count[NUM_IP_TYPES];
-    unsigned int                peer_nofilter_count[NUM_IP_TYPES];
+    unsigned int                dest_filter_count[NUM_IP_TYPES];
+    dest_filter_list_t **       dest_filter_list[NUM_IP_TYPES];
 } interface_t;
 
 // DNS state/closure (private to dns decode/encode files)
@@ -172,9 +180,6 @@ extern unsigned int             filtering_enabled;
 
 // Global filter list, defined in filter.c
 extern filter_list_t *          global_filter_list;
-
-// Count of unique outbound filters in use across all interfaces, defined in filter.c
-extern unsigned int             unique_outbound_filter_count;
 
 // Interface lists, defined in interface.c
 extern interface_t *            configured_interface_list;
@@ -213,6 +218,11 @@ extern unsigned int set_interface_list(
 extern interface_t * get_interface_by_name(
     const char *                name);
 
+// Get the outbound filter list an interface uses for a peer
+filter_list_t * get_filter_list_for_peer(
+    interface_t *               interface,
+    interface_t *               peer);
+
 // Set the configured interface list
 extern void set_ip_interface_lists(void);
 
@@ -240,6 +250,14 @@ extern void set_interface_inbound_filter_list(
 extern void set_interface_outbound_filter_list(
     interface_t *               interface,
     filter_allow_deny_t         allow_deny,
+    char **                     list,
+    unsigned int                count);
+
+// Set an interface peer outbound filter list
+void set_interface_peer_outbound_filter_list(
+    interface_t *               interface,
+    interface_t *               peer,
+    const filter_allow_deny_t   allow_deny,
     char **                     list,
     unsigned int                count);
 

--- a/config.c
+++ b/config.c
@@ -56,6 +56,8 @@
 #define KEY_DENY_INBOUND_FILTERS        "deny-inbound-filters"
 #define KEY_ALLOW_OUTBOUND_FILTERS      "allow-outbound-filters"
 #define KEY_DENY_OUTBOUND_FILTERS       "deny-outbound-filters"
+#define KEY_PEER_ALLOW_OUTBOUND_FILTERS "peer-allow-outbound-filters"
+#define KEY_PEER_DENY_OUTBOUND_FILTERS  "peer-deny-outbound-filters"
 
 // Global config flags
 static unsigned int                     global_disable_ipv4 = 0;
@@ -234,6 +236,7 @@ void read_config(void)
     char *                      list_array[MAX_LIST_ARRAY];
     unsigned int                list_array_count;
     interface_t *               interface;
+    interface_t *               peer;
     char *                      line;
     char *                      value;
     unsigned int                index;
@@ -541,7 +544,58 @@ void read_config(void)
                 list_array_count = split_comma_list(value, list_array);
                 set_interface_outbound_filter_list(interface, DENY, list_array, list_array_count);
             }
-            // FIXME put some cool stuff here for peer interface filters...
+            else if (strcmp(line, KEY_PEER_ALLOW_OUTBOUND_FILTERS) == 0)
+            {
+                if (filtering_enabled == 0)
+                {
+                    fatal("%s line %u: %s cannot be combined with %s\n", config_filename, config_lineno,
+                          KEY_PEER_ALLOW_OUTBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
+                }
+
+                list_array_count = split_comma_list(value, list_array);
+                if (list_array_count < 2)
+                {
+                    fatal("%s line %u: missing filter\n", config_filename, config_lineno);
+                }
+
+                peer = get_interface_by_name(list_array[0]);
+                if (peer == NULL)
+                {
+                    fatal("%s line %u: Interface \"%s\" is not in the [global] interfaces list\n", config_filename, config_lineno, list_array[0]);
+                }
+
+                if (interface->peer_outbound_filter_list && interface->peer_outbound_filter_list[peer->index])
+                {
+                    fatal("%s line %u: Only one peer outbound filter list per peer is allowed\n", config_filename, config_lineno);
+                }
+                set_interface_peer_outbound_filter_list(interface, peer, ALLOW, &list_array[1], list_array_count - 1);
+            }
+            else if (strcmp(line, KEY_PEER_DENY_OUTBOUND_FILTERS) == 0)
+            {
+                if (filtering_enabled == 0)
+                {
+                    fatal("%s line %u: %s cannot be combined with %s\n", config_filename, config_lineno,
+                          KEY_PEER_DENY_OUTBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
+                }
+
+                list_array_count = split_comma_list(value, list_array);
+                if (list_array_count < 2)
+                {
+                    fatal("%s line %u: missing filter\n", config_filename, config_lineno);
+                }
+
+                peer = get_interface_by_name(list_array[0]);
+                if (peer == NULL)
+                {
+                    fatal("%s line %u: Interface \"%s\" is not in the [global] interfaces list\n", config_filename, config_lineno, list_array[0]);
+                }
+
+                if (interface->peer_outbound_filter_list && interface->peer_outbound_filter_list[peer->index])
+                {
+                    fatal("%s line %u: Only one peer outbound filter list per peer is allowed\n", config_filename, config_lineno);
+                }
+                set_interface_peer_outbound_filter_list(interface, peer, ALLOW, &list_array[1], list_array_count - 1);
+            }
             else
             {
                 fatal("%s line %u: Unknown interface parameter \"%s\"\n", config_filename, config_lineno, line);
@@ -559,10 +613,31 @@ void read_config(void)
 
 
 //
-// Dump the configuration
+// Dump the configuration for human readability
 //
-static void dump_filter_list(
-    char *                      name,
+static void print_peer_list(
+    char *                      prefix,
+    unsigned int                count,
+    interface_t *               list[])
+{
+    unsigned int                index;
+
+    printf("%s: ", prefix);
+    for (index = 0; index < count; index++)
+    {
+        if (index < count - 1)
+        {
+            printf("%s, ", list[index]->name);
+        }
+        else
+        {
+            printf("%s\n", list[index]->name);
+        }
+    }
+}
+
+static void print_filter_list(
+    char *                      prefix,
     filter_list_t *             list)
 {
     unsigned int                index;
@@ -570,7 +645,7 @@ static void dump_filter_list(
 
     if (list)
     {
-        printf("  %s (%s): ", name, list->allow_deny == ALLOW ? "allow" : "deny");
+        printf("%s: (%s) ", prefix, list->allow_deny == ALLOW ? "allow" : "deny");
         for (index = 0; index < list->count; index++)
         {
             dns_labels_to_string(list->names[index]->labels, list->names[index]->length, string);
@@ -587,19 +662,123 @@ static void dump_filter_list(
     }
     else
     {
-        printf("  %s: (none)\n", name);
+        printf("%s: none\n", prefix);
     }
 }
 
+static void print_interface_ip(
+    interface_t *               interface,
+    ip_type_t                   ip_type)
+{
+    interface_t *               peer;
+    interface_t *               peer2;
+    dest_filter_list_t **            peer_filter_list;
+    dest_filter_list_t *             peer_filter;
+    filter_list_t *             filter_list;
+    unsigned int                peer_filter_index;
+    unsigned int                peer_index;
+    unsigned int                peer2_index;
+    unsigned int                count;
 
-//
-// Dump the configuration
-//
+    if (interface->disable_ip[ip_type] == 0)
+    {
+        printf("  %s configuration:\n", ip_type == IPV4 ? "IPv4" : "IPv6");
+        printf("   address: %s\n", ip_type == IPV4 ? interface->ipv4_addr_str : interface->ipv6_addr_str);
+
+        // Print peer interface list
+        for (peer_index = 0; peer_index < configured_interface_count; peer_index++)
+        {
+            peer = &configured_interface_list[peer_index];
+            if (peer == interface || peer->disable_ip[ip_type])
+            {
+                continue;
+            }
+            break;
+        }
+        printf("   peer interfaces: %s", peer->name);
+        for (peer_index = peer_index + 1; peer_index < configured_interface_count; peer_index++)
+        {
+            peer = &configured_interface_list[peer_index];
+            if (peer == interface || peer->disable_ip[ip_type])
+            {
+                continue;
+            }
+            printf(", %s", peer->name);
+        }
+        printf("\n");
+
+        // Print peer source list
+        count = 1;
+        for (peer_index = 0; peer_index < configured_interface_count; peer_index++)
+        {
+            peer = &configured_interface_list[peer_index];
+            if (peer == interface || peer->disable_ip[ip_type])
+            {
+                continue;
+            }
+
+            filter_list = get_filter_list_for_peer(interface, peer);
+
+            for (peer2_index = 0; peer2_index < peer_index; peer2_index++)
+            {
+                peer2 = &configured_interface_list[peer2_index];
+                if (peer2 == interface || peer2->disable_ip[ip_type])
+                {
+                    continue;
+                }
+
+                // Have we already seen this filter list?
+                if (get_filter_list_for_peer(interface, peer2) == filter_list)
+                {
+                    break;
+                }
+            }
+
+            if (peer2_index >= peer_index)
+            {
+                printf("   source %u:\n", count++);
+                printf("    interfaces: %s", peer->name);
+                for (peer2_index = peer_index + 1; peer2_index < configured_interface_count; peer2_index++)
+                {
+                    peer2 = &configured_interface_list[peer2_index];
+                    if (peer2 == interface || peer2->disable_ip[ip_type])
+                    {
+                        continue;
+                    }
+
+                    if (get_filter_list_for_peer(interface, peer2) == filter_list)
+                    {
+                        printf(", %s", peer2->name);
+                    }
+                }
+                printf("\n");
+                print_filter_list("    filter", filter_list);
+            }
+        }
+
+        // Print peer destination list
+        count = 1;
+        peer_filter_list = interface->dest_filter_list[ip_type];
+        for (peer_filter_index = 0; peer_filter_index < interface->dest_filter_count[ip_type]; peer_filter_index++)
+        {
+            peer_filter = peer_filter_list[peer_filter_index];
+
+            printf("   destination %u:\n", count++);
+            print_peer_list("    interfaces", peer_filter->peer_count, peer_filter->peer_list);
+            print_filter_list("    filter", peer_filter_list[peer_filter_index]->filter);
+        }
+    }
+    else
+    {
+        printf("  %s disabled\n", ip_type == IPV4 ? "IPv4" : "IPv6");
+    }
+}
+
 void dump_config(void)
 {
     interface_t *               interface;
+    unsigned int                interface_index;
     unsigned int                index;
-    unsigned int                peer;
 
     // Global section
     printf("\nGlobal settings:\n");
@@ -613,52 +792,36 @@ void dump_config(void)
     } else {
         printf(" disable ipv6 = false\n");
     }
-    dump_filter_list("global filter", global_filter_list);
+    print_filter_list(" global filter", global_filter_list);
+    printf("\n");
 
-    // Interfaces
-    printf("\nInterface list:\n");
-    for (index = 0; index < configured_interface_count; index++)
+    printf("Interfaces:\n");
+
+    for (interface_index = 0; interface_index < configured_interface_count; interface_index++)
     {
-        interface = &configured_interface_list[index];
-        printf(" %s (%u)\n", interface->name, interface->if_index);
-        if (interface->disable_ip[IPV4] == 0)
+        interface = &configured_interface_list[interface_index];
+        printf(" %s:\n", interface->name);
+
+        // Print interface configuration
+        print_filter_list("  inbound filter", interface->inbound_filter_list);
+        print_filter_list("  outbound filter", interface->outbound_filter_list);
+
+        if (interface->peer_outbound_filter_list)
         {
-            printf("  ipv4 address %s\n", interface->ipv4_addr_str);
-            printf("   peer interfaces:");
-            for (peer = 0; peer < interface->peer_count[IPV4]; peer++)
+            printf("  peer specific outbound filters:\n");
+            for (index = 0; index < configured_interface_count; index++)
             {
-                printf(" %s", interface->peer_list[IPV4][peer]->name);
+                if (interface->peer_outbound_filter_list[index])
+                {
+                    printf("   %s", configured_interface_list[index].name);
+                    print_filter_list("", interface->peer_outbound_filter_list[index]);
+                }
             }
-            printf("\n");
-        }
-        else
-        {
-            printf("  ipv4 disabled\n");
         }
 
-        if (interface->disable_ip[IPV6] == 0)
-        {
-            printf("  ipv6 address %s\n", interface->ipv6_addr_str);
-            printf("   peer interfaces:");
-            for (peer = 0; peer < interface->peer_count[IPV6]; peer++)
-            {
-                printf(" %s", interface->peer_list[IPV6][peer]->name);
-            }
-            printf("\n");
-        }
-        else
-        {
-            printf("  ipv6 disabled\n");
-        }
-
-        if (interface->inbound_filter_list)
-        {
-            dump_filter_list("inbound filter", interface->inbound_filter_list);
-        }
-        if (interface->outbound_filter_list)
-        {
-            dump_filter_list("outbound filter", interface->outbound_filter_list);
-        }
+        // Print interface IP configuration
+        print_interface_ip(interface, IPV4);
+        print_interface_ip(interface, IPV6);
         printf("\n");
     }
 }

--- a/config.c
+++ b/config.c
@@ -340,11 +340,14 @@ void read_config(void)
                 fatal("%s line %u: %s cannot be combined with %s\n", config_filename, config_lineno,
                       KEY_ALLOW_INBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
             }
-            list_array_count = split_comma_list(value, list_array);
-            if (set_global_filter_list(ALLOW, list_array, list_array_count))
+
+            if (global_filter_list)
             {
                 fatal("%s line %u: Only one global filter list is allowed\n", config_filename, config_lineno);
             }
+
+            list_array_count = split_comma_list(value, list_array);
+            set_global_filter_list(ALLOW, list_array, list_array_count);
         }
         else if (strcmp(line, KEY_DENY_INBOUND_FILTERS) == 0)
         {
@@ -353,11 +356,14 @@ void read_config(void)
                 fatal("%s line %u: %s cannot be combined with %s\n", config_filename, config_lineno,
                       KEY_DENY_INBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
             }
-            list_array_count = split_comma_list(value, list_array);
-            if (set_global_filter_list(DENY, list_array, list_array_count))
+
+            if (global_filter_list)
             {
                 fatal("%s line %u: Only one global filter list is allowed\n", config_filename, config_lineno);
             }
+
+            list_array_count = split_comma_list(value, list_array);
+            set_global_filter_list(DENY, list_array, list_array_count);
         }
         else
         {
@@ -475,11 +481,13 @@ void read_config(void)
                           KEY_ALLOW_INBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
                 }
 
-                list_array_count = split_comma_list(value, list_array);
-                if (set_interface_inbound_filter_list(interface, ALLOW, list_array, list_array_count))
+                if (interface->inbound_filter_list)
                 {
                     fatal("%s line %u: Only one inbound filter list per interface is allowed\n", config_filename, config_lineno);
                 }
+
+                list_array_count = split_comma_list(value, list_array);
+                set_interface_inbound_filter_list(interface, ALLOW, list_array, list_array_count);
             }
             else if (strcmp(line, KEY_DENY_INBOUND_FILTERS) == 0)
             {
@@ -489,11 +497,13 @@ void read_config(void)
                           KEY_DENY_INBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
                 }
 
-                list_array_count = split_comma_list(value, list_array);
-                if (set_interface_inbound_filter_list(interface, DENY, list_array, list_array_count))
+                if (interface->inbound_filter_list)
                 {
                     fatal("%s line %u: Only one inbound filter list per interface is allowed\n", config_filename, config_lineno);
                 }
+
+                list_array_count = split_comma_list(value, list_array);
+                set_interface_inbound_filter_list(interface, DENY, list_array, list_array_count);
             }
             else if (strcmp(line, KEY_ALLOW_OUTBOUND_FILTERS) == 0)
             {
@@ -503,11 +513,13 @@ void read_config(void)
                           KEY_ALLOW_OUTBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
                 }
 
-                list_array_count = split_comma_list(value, list_array);
-                if (set_interface_outbound_filter_list(interface, ALLOW, list_array, list_array_count))
+                if (interface->outbound_filter_list)
                 {
                     fatal("%s line %u: Only one outbound filter list per interface is allowed\n", config_filename, config_lineno);
                 }
+
+                list_array_count = split_comma_list(value, list_array);
+                set_interface_outbound_filter_list(interface, ALLOW, list_array, list_array_count);
             }
             else if (strcmp(line, KEY_DENY_OUTBOUND_FILTERS) == 0)
             {
@@ -517,11 +529,13 @@ void read_config(void)
                           KEY_DENY_OUTBOUND_FILTERS, KEY_DISABLE_PACKET_FILTERING);
                 }
 
-                list_array_count = split_comma_list(value, list_array);
-                if (set_interface_outbound_filter_list(interface, DENY, list_array, list_array_count))
+                if (interface->outbound_filter_list)
                 {
                     fatal("%s line %u: Only one outbound filter list per interface is allowed\n", config_filename, config_lineno);
                 }
+
+                list_array_count = split_comma_list(value, list_array);
+                set_interface_outbound_filter_list(interface, DENY, list_array, list_array_count);
             }
             // FIXME put some cool stuff here for peer interface filters...
             else
@@ -552,11 +566,19 @@ static void dump_filter_list(
 
     if (list)
     {
-        printf("  %s (%s):\n", name, list->allow_deny == ALLOW ? "allow" : "deny");
+        printf("  %s (%s): ", name, list->allow_deny == ALLOW ? "allow" : "deny");
         for (index = 0; index < list->count; index++)
         {
             dns_labels_to_string(list->names[index]->labels, list->names[index]->length, string);
-            printf("   %s\n", string);
+            if (index < list->count - 1)
+            {
+                printf("%s, ", string);
+
+            }
+            else
+            {
+                printf("%s\n", string);
+            }
         }
     }
     else
@@ -627,11 +649,11 @@ void dump_config(void)
 
         if (interface->inbound_filter_list)
         {
-            dump_filter_list("inbound filter list", interface->inbound_filter_list);
+            dump_filter_list("inbound filter", interface->inbound_filter_list);
         }
         if (interface->outbound_filter_list)
         {
-            dump_filter_list("outbound filter list", interface->outbound_filter_list);
+            dump_filter_list("outbound filter", interface->outbound_filter_list);
         }
         printf("\n");
     }

--- a/config.c
+++ b/config.c
@@ -594,7 +594,7 @@ void read_config(void)
                 {
                     fatal("%s line %u: Only one peer outbound filter list per peer is allowed\n", config_filename, config_lineno);
                 }
-                set_interface_peer_outbound_filter_list(interface, peer, ALLOW, &list_array[1], list_array_count - 1);
+                set_interface_peer_outbound_filter_list(interface, peer, DENY, &list_array[1], list_array_count - 1);
             }
             else
             {
@@ -672,8 +672,8 @@ static void print_interface_ip(
 {
     interface_t *               peer;
     interface_t *               peer2;
-    dest_filter_list_t **            peer_filter_list;
-    dest_filter_list_t *             peer_filter;
+    dest_filter_list_t **       peer_filter_list;
+    dest_filter_list_t *        peer_filter;
     filter_list_t *             filter_list;
     unsigned int                peer_filter_index;
     unsigned int                peer_index;

--- a/config.c
+++ b/config.c
@@ -643,26 +643,31 @@ static void print_filter_list(
     unsigned int                index;
     unsigned char               string[DNS_MAX_NAME_LEN];
 
-    if (list)
-    {
-        printf("%s: (%s) ", prefix, list->allow_deny == ALLOW ? "allow" : "deny");
-        for (index = 0; index < list->count; index++)
-        {
-            dns_labels_to_string(list->names[index]->labels, list->names[index]->length, string);
-            if (index < list->count - 1)
-            {
-                printf("%s, ", string);
-
-            }
-            else
-            {
-                printf("%s\n", string);
-            }
-        }
-    }
-    else
+    if (list == NULL)
     {
         printf("%s: none\n", prefix);
+        return;
+    }
+
+    if (list->allow_deny == DENY_ALL)
+    {
+        printf("%s: (deny all)\n", prefix);
+        return;
+    }
+
+    printf("%s: (%s) ", prefix, list->allow_deny == ALLOW ? "allow" : "deny");
+    for (index = 0; index < list->count; index++)
+    {
+        dns_labels_to_string(list->names[index]->labels, list->names[index]->length, string);
+        if (index < list->count - 1)
+        {
+            printf("%s, ", string);
+
+        }
+        else
+        {
+            printf("%s\n", string);
+        }
     }
 }
 

--- a/config.c
+++ b/config.c
@@ -272,10 +272,14 @@ void read_config(void)
                 fatal("%s line %u: A minimum of 2 interfaces are required\n", config_filename, config_lineno);
             }
 
-            if (set_interface_list(list_array, list_array_count))
+            // Error if an interface list was previously defined
+            if (configured_interface_list)
             {
                 fatal("%s line %u: Only one interface list is allowed\n", config_filename, config_lineno);
             }
+
+            // Set the interface list
+            set_interface_list(list_array, list_array_count);
         }
         else if (strcmp(line, KEY_DISABLE_IPV4) == 0)
         {

--- a/dns_decode.c
+++ b/dns_decode.c
@@ -428,7 +428,7 @@ static unsigned int dns_decode_header(
         if (np == NULL)
         {
             // Drop the packet
-            logger("Cannot allocate memory: %s\n", strerror(errno));
+            logger("Cannot allocate memory to expand query list: %s\n", strerror(errno));
             return 0;
         }
         state->query_list = np;
@@ -454,7 +454,7 @@ static unsigned int dns_decode_header(
         if (np == NULL)
         {
             // Drop the packet
-            logger("Cannot allocate memory: %s\n", strerror(errno));
+            logger("Cannot allocate memory to expand resource record list: %s\n", strerror(errno));
             return 0;
         }
         state->rr_list = np;

--- a/filter.c
+++ b/filter.c
@@ -167,7 +167,7 @@ static int filter_list_compare(
 //
 // Set the global filter list
 //
-unsigned int set_global_filter_list(
+void set_global_filter_list(
     const filter_allow_deny_t   allow_deny,
     char **                     list,
     unsigned int                count)
@@ -181,7 +181,7 @@ unsigned int set_global_filter_list(
 //
 // Set an interface inbound filter list
 //
-unsigned int set_interface_inbound_filter_list(
+void set_interface_inbound_filter_list(
     interface_t *               interface,
     const filter_allow_deny_t   allow_deny,
     char **                     list,
@@ -198,7 +198,7 @@ unsigned int set_interface_inbound_filter_list(
     {
         logger("Interface %s inbound filter discarded (duplicate of the global filter)\n", interface->name);
         filter_list_destroy(filter_list);
-        return 0;
+        return;
     }
 
     // Check if this is a duplicate of an already existing interface filter list
@@ -222,7 +222,7 @@ unsigned int set_interface_inbound_filter_list(
 //
 // Set an interface outbound filter list
 //
-unsigned int set_interface_outbound_filter_list(
+void set_interface_outbound_filter_list(
     interface_t *               interface,
     const filter_allow_deny_t   allow_deny,
     char **                     list,

--- a/filter.c
+++ b/filter.c
@@ -183,55 +183,6 @@ static filter_list_t * filter_list_create(
 
 
 //
-// Destroy a filter list
-//
-static void filter_list_destroy(
-   filter_list_t *              filter_list)
-{
-    unsigned int                index;
-
-    // Free the dns names
-    for (index = 0; index < filter_list->count; index++)
-    {
-        free((void *) filter_list->names[index]);
-    }
-
-    // Free the names array and the list itself
-    free(filter_list->names);
-    free(filter_list);
-}
-
-
-//
-// Compare two filter lists for equality
-//
-static int filter_list_compare(
-   const filter_list_t *        l1,
-   const filter_list_t *        l2)
-{
-    if (l1->allow_deny != l2->allow_deny || l1->count != l2->count)
-    {
-        return 1;
-    }
-
-    for (unsigned int index = 0; index < l1->count; index++)
-    {
-        if (l1->names[index]->length != l2->names[index]->length)
-        {
-            return 1;
-        }
-
-        if (memcmp (l1->names[index]->labels, l2->names[index]->labels, l1->names[index]->length))
-        {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-
-//
 // Set the global filter list
 //
 void set_global_filter_list(
@@ -254,7 +205,6 @@ void set_interface_inbound_filter_list(
     unsigned int                count)
 {
     filter_list_t *             filter_list;
-    unsigned int                index;
 
     // Create the list
     filter_list = filter_list_create(allow_deny, list, count);
@@ -263,7 +213,6 @@ void set_interface_inbound_filter_list(
     if (filter_list == global_filter_list)
     {
         logger("Interface %s inbound filter discarded (duplicate of the global filter)\n", interface->name);
-        filter_list_destroy(filter_list);
         return;
     }
 

--- a/filter.c
+++ b/filter.c
@@ -42,9 +42,6 @@ unsigned int                    filtering_enabled = 1;
 // The global filter list
 filter_list_t *                 global_filter_list = NULL;
 
-// Count of unique outbound filters in use across all interfaces
-unsigned int                    unique_outbound_filter_count = 0;
-
 // Cached filter lists
 static filter_list_t **         filter_list_cache = NULL;
 static unsigned int             filter_list_cache_allocated = 0;
@@ -231,8 +228,6 @@ void set_interface_outbound_filter_list(
     unsigned int                count)
 {
     filter_list_t *             filter_list;
-    unsigned int                filter_list_unique = 1;
-    unsigned int                index;
 
     // Create the list
     filter_list = filter_list_create(allow_deny, list, count);
@@ -244,23 +239,38 @@ void set_interface_outbound_filter_list(
         return;
     }
 
-    // FIXME the uniqiue check should be done later...
-    // Check if this is a duplicate of an already existing interface filter list
-    for (index = 0; index < configured_interface_count; index++)
+    // Assign the list to the interface
+    interface->outbound_filter_list = filter_list;
+}
+
+
+//
+// Set an interface peer outbound filter list
+//
+void set_interface_peer_outbound_filter_list(
+    interface_t *               interface,
+    interface_t *               peer,
+    const filter_allow_deny_t   allow_deny,
+    char **                     list,
+    unsigned int                count)
+{
+    filter_list_t *             filter_list;
+
+    // Allocate the peer outbound filter list if it doesn't exist
+    if (interface->peer_outbound_filter_list == NULL)
     {
-        if (filter_list == configured_interface_list[index].outbound_filter_list)
+        interface->peer_outbound_filter_list = calloc(configured_interface_count, sizeof(filter_list_t *));
+        if (interface->peer_outbound_filter_list == NULL)
         {
-            filter_list_unique = 0;
-            break;
+            fatal("Cannot allocate memory: %s\n", strerror(errno));
         }
     }
 
-    if (filter_list_unique) {
-        unique_outbound_filter_count += 1;
-    }
+    // Create the list
+    filter_list = filter_list_create(allow_deny, list, count);
 
-    // Assign the list to the interface
-    interface->outbound_filter_list = filter_list;
+    // Set the peer outbound filter list
+    interface->peer_outbound_filter_list[peer->index] = filter_list;
 }
 
 

--- a/filter.c
+++ b/filter.c
@@ -36,6 +36,10 @@
 #include "common.h"
 
 
+// Token used to indicate a DENY_ALL filter
+#define DENY_ALL_TOKEN          "<all>"
+
+
 // Packet filtering enable flag
 unsigned int                    filtering_enabled = 1;
 
@@ -100,10 +104,22 @@ static filter_list_t * filter_list_create(
     unsigned int                cache_index;
     unsigned int                index;
 
-    // Sort the array
-    qsort(list, count, sizeof(list[0]), qsort_strcmp);
+    // Allocate the filter list
+    filter_list = calloc(1, sizeof(filter_list_t));
+    if (filter_list == NULL)
+    {
+        fatal("Cannot allocate memory: %s\n", strerror(errno));
+    }
 
-    // Remove duplicates
+    // Check for a DENY_ALL filter
+    if (allow_deny == DENY && count == 1 && strcmp(list[0], DENY_ALL_TOKEN) == 0)
+    {
+        filter_list->allow_deny = DENY_ALL;
+        return filter_list;
+    }
+
+    // Sort the array and remove duplicates
+    qsort(list, count, sizeof(list[0]), qsort_strcmp);
     for (index = 1; index < count; index++)
     {
         if (strcmp(list[index - 1], list[index]) == 0)
@@ -115,13 +131,6 @@ static filter_list_t * filter_list_create(
             }
             count--;
         }
-    }
-
-    // Allocate the filter list
-    filter_list = calloc(1, sizeof(filter_list_t));
-    if (filter_list == NULL)
-    {
-        fatal("Cannot allocate memory: %s\n", strerror(errno));
     }
 
     // Allocate the name list
@@ -284,6 +293,13 @@ static unsigned int filter_list_allowed(
     unsigned int                index;
     unsigned int                match = 0;
 
+    // Check for a DENY_ALL filter
+    if (filter_list->allow_deny == DENY_ALL)
+    {
+        return 0;
+    }
+
+    // Check for a match in the filter list
     for (index = 0; index < filter_list->count; index++)
     {
         if (dns_subset_match(name, filter_list->names[index]))

--- a/filter.c
+++ b/filter.c
@@ -45,6 +45,10 @@ filter_list_t *                 global_filter_list = NULL;
 // Count of unique outbound filters in use across all interfaces
 unsigned int                    unique_outbound_filter_count = 0;
 
+// Cached filter lists
+static filter_list_t **         filter_list_cache = NULL;
+static unsigned int             filter_list_cache_allocated = 0;
+static unsigned int             filter_list_cache_count = 0;
 
 
 //
@@ -59,6 +63,35 @@ static int qsort_strcmp(
 
 
 //
+// Compare two filter lists for equality
+//
+static int filter_list_compare(
+   const filter_list_t *        l1,
+   const filter_list_t *        l2)
+{
+    if (l1->allow_deny != l2->allow_deny || l1->count != l2->count)
+    {
+        return 1;
+    }
+
+    for (unsigned int index = 0; index < l1->count; index++)
+    {
+        if (l1->names[index]->length != l2->names[index]->length)
+        {
+            return 1;
+        }
+
+        if (memcmp (l1->names[index]->labels, l2->names[index]->labels, l1->names[index]->length))
+        {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+//
 // Create a filter list
 //
 static filter_list_t * filter_list_create(
@@ -67,6 +100,7 @@ static filter_list_t * filter_list_create(
     unsigned int                count)
 {
     filter_list_t *             filter_list;
+    unsigned int                cache_index;
     unsigned int                index;
 
     // Sort the array
@@ -111,6 +145,39 @@ static filter_list_t * filter_list_create(
     filter_list->count = count;
     filter_list->allow_deny = allow_deny;
 
+    // If the new filter list is a duplicate, use the previously cached filter
+    for (cache_index = 0; cache_index < filter_list_cache_count; cache_index++)
+    {
+        if (filter_list_compare(filter_list, filter_list_cache[cache_index]) == 0)
+        {
+            // Destroy the new filter
+            for (index = 0; index < filter_list->count; index++)
+            {
+                free((void *) filter_list->names[index]);
+            }
+            free(filter_list->names);
+            free(filter_list);
+
+            // Return the previously cached filter
+            return filter_list_cache[cache_index];
+        }
+    }
+
+    // Do we need to (re)allocate the filter list cache?
+    if (filter_list_cache_count >= filter_list_cache_allocated)
+    {
+        filter_list_cache_allocated += 8;
+
+        filter_list_cache = realloc(filter_list_cache, filter_list_cache_allocated * sizeof(filter_list_t));
+        if (filter_list_cache == NULL)
+        {
+            fatal("Cannot allocate memory: %s\n", strerror(errno));
+        }
+    }
+
+    // Cache the new filter list and return
+    filter_list_cache[filter_list_cache_count] = filter_list;
+    filter_list_cache_count += 1;
     return filter_list;
 }
 
@@ -193,7 +260,7 @@ void set_interface_inbound_filter_list(
     filter_list = filter_list_create(allow_deny, list, count);
 
     // Check if this is a duplicate of the global list
-    if (global_filter_list && filter_list_compare(global_filter_list, filter_list) == 0)
+    if (filter_list == global_filter_list)
     {
         logger("Interface %s inbound filter discarded (duplicate of the global filter)\n", interface->name);
         filter_list_destroy(filter_list);
@@ -233,15 +300,19 @@ void set_interface_outbound_filter_list(
     // Create the list
     filter_list = filter_list_create(allow_deny, list, count);
 
+    // Check if this is a duplicate of the global list
+    if (filter_list == global_filter_list)
+    {
+        logger("Interface %s outbound filter discarded (duplicate of the global filter)\n", interface->name);
+        return;
+    }
+
+    // FIXME the uniqiue check should be done later...
     // Check if this is a duplicate of an already existing interface filter list
     for (index = 0; index < configured_interface_count; index++)
     {
-        if (configured_interface_list[index].outbound_filter_list &&
-            filter_list_compare(configured_interface_list[index].outbound_filter_list, filter_list) == 0)
+        if (filter_list == configured_interface_list[index].outbound_filter_list)
         {
-            // If the new list is a duplicate, adopt the existing list
-            filter_list_destroy(filter_list);
-            filter_list = configured_interface_list[index].outbound_filter_list;
             filter_list_unique = 0;
             break;
         }

--- a/filter.c
+++ b/filter.c
@@ -198,6 +198,11 @@ void set_global_filter_list(
 {
     // Create the list
     global_filter_list = filter_list_create(allow_deny, list, count);
+
+    if (global_filter_list->allow_deny == DENY_ALL)
+    {
+        fatal("The global filter list cannot be deny all\n");
+    }
 }
 
 

--- a/filter.c
+++ b/filter.c
@@ -174,7 +174,6 @@ void set_global_filter_list(
 {
     // Create the list
     global_filter_list = filter_list_create(allow_deny, list, count);
-    return 0;
 }
 
 
@@ -215,7 +214,6 @@ void set_interface_inbound_filter_list(
 
     // Assign the list to the interface
     interface->inbound_filter_list = filter_list;
-    return 0;
 }
 
 
@@ -255,7 +253,6 @@ void set_interface_outbound_filter_list(
 
     // Assign the list to the interface
     interface->outbound_filter_list = filter_list;
-    return 0;
 }
 
 

--- a/filter.c
+++ b/filter.c
@@ -165,7 +165,7 @@ static filter_list_t * filter_list_create(
     {
         filter_list_cache_allocated += 8;
 
-        filter_list_cache = realloc(filter_list_cache, filter_list_cache_allocated * sizeof(filter_list_t));
+        filter_list_cache = realloc(filter_list_cache, filter_list_cache_allocated * sizeof(filter_list_t *));
         if (filter_list_cache == NULL)
         {
             fatal("Cannot allocate memory: %s\n", strerror(errno));

--- a/filter.c
+++ b/filter.c
@@ -216,18 +216,6 @@ void set_interface_inbound_filter_list(
         return;
     }
 
-    // Check if this is a duplicate of an already existing interface filter list
-    for (index = 0; index < configured_interface_count; index++)
-    {
-        if (configured_interface_list[index].inbound_filter_list &&
-            filter_list_compare(configured_interface_list[index].inbound_filter_list, filter_list) == 0)
-        {
-            filter_list_destroy(filter_list);
-            filter_list = configured_interface_list[index].inbound_filter_list;
-            break;
-        }
-    }
-
     // Assign the list to the interface
     interface->inbound_filter_list = filter_list;
 }

--- a/filter.c
+++ b/filter.c
@@ -172,12 +172,6 @@ unsigned int set_global_filter_list(
     char **                     list,
     unsigned int                count)
 {
-    // If a list was previously defined, return error
-    if (global_filter_list)
-    {
-        return 1;
-    }
-
     // Create the list
     global_filter_list = filter_list_create(allow_deny, list, count);
     return 0;
@@ -195,12 +189,6 @@ unsigned int set_interface_inbound_filter_list(
 {
     filter_list_t *             filter_list;
     unsigned int                index;
-
-    // If a list was previously defined, return error
-    if (interface->inbound_filter_list)
-    {
-        return 1;
-    }
 
     // Create the list
     filter_list = filter_list_create(allow_deny, list, count);
@@ -243,12 +231,6 @@ unsigned int set_interface_outbound_filter_list(
     filter_list_t *             filter_list;
     unsigned int                filter_list_unique = 1;
     unsigned int                index;
-
-    // If a list was previously defined, return error
-    if (interface->outbound_filter_list)
-    {
-        return 1;
-    }
 
     // Create the list
     filter_list = filter_list_create(allow_deny, list, count);

--- a/interface.c
+++ b/interface.c
@@ -261,7 +261,7 @@ static void build_interface_dest_lists(
         // Create the the permanent peer filter list array
         interface->dest_filter_count[ip_type] = work_list_used;
         interface->dest_filter_list[ip_type] = malloc(work_list_used * sizeof(dest_filter_list_t *));
-        if (work_list == NULL)
+        if (interface->dest_filter_list[ip_type] == NULL)
         {
             fatal("Cannot allocate memory: %s\n", strerror(errno));
         }
@@ -269,6 +269,8 @@ static void build_interface_dest_lists(
         // Save each peer filter list
         for (index = 0; index < work_list_used; index++)
         {
+            work_list_slot = work_list[index];
+
             // Allocate memory for the peer filter list
             dest_filter_list = malloc(sizeof(dest_filter_list_t) + work_list_slot->peer_count * sizeof(struct interface *));
             if (dest_filter_list == NULL)
@@ -278,7 +280,6 @@ static void build_interface_dest_lists(
             interface->dest_filter_list[ip_type][index] = dest_filter_list;
 
             // Copy the filter and peer list from the work list slot
-            work_list_slot = work_list[index];
             dest_filter_list->filter = work_list_slot->filter;
             dest_filter_list->peer_count = work_list_slot->peer_count;
             for (peer_index = 0; peer_index < work_list_slot->peer_count; peer_index++)

--- a/interface.c
+++ b/interface.c
@@ -55,12 +55,6 @@ unsigned int set_interface_list(
 {
     unsigned int                index;
 
-    // If a list was previously defined, return error
-    if (configured_interface_list != NULL)
-    {
-        return 1;
-    }
-
     // Allocate the list
     configured_interface_list = calloc(count, sizeof(interface_t));
     if (configured_interface_list == NULL)
@@ -103,7 +97,7 @@ interface_t * get_interface_by_name(
 
 
 //
-// Build and validate a list of interfaces for an ip type
+// Build and validate the list of interfaces for an ip type
 //
 static void build_interface_list(
     ip_type_t                   ip_type)

--- a/interface.c
+++ b/interface.c
@@ -70,6 +70,7 @@ unsigned int set_interface_list(
         {
             fatal("Cannot allocate memory: %s\n", strerror(errno));
         }
+        configured_interface_list[index].index = index;
     }
 
     configured_interface_count = count;
@@ -93,6 +94,22 @@ interface_t * get_interface_by_name(
         }
     }
     return NULL;
+}
+
+
+//
+// Get the outbound filter list an interface uses for a peer
+//
+filter_list_t * get_filter_list_for_peer(
+    interface_t *               interface,
+    interface_t *               peer)
+{
+    if (interface->peer_outbound_filter_list && interface->peer_outbound_filter_list[peer->index])
+    {
+        return interface->peer_outbound_filter_list[peer->index];
+    }
+
+    return interface->outbound_filter_list;
 }
 
 
@@ -149,37 +166,43 @@ static void build_interface_list(
 
 
 //
-// Set the configured interface list
+// Build the interface peer lists
 //
-static void build_interface_peer_lists(
+static void build_interface_dest_lists(
     ip_type_t                   ip_type)
 {
     interface_t *               interface;
     interface_t *               peer;
-    unsigned int                index;
+    filter_list_t *             filter_list;
+    dest_filter_list_t *        dest_filter_list;
+    dest_filter_list_t **       work_list;
+    dest_filter_list_t *        work_list_slot;
+    unsigned int                work_list_used;
+    unsigned int                interface_index;
     unsigned int                peer_index;
-    unsigned int                filter_index;
+    unsigned int                index;
 
+    // Allocate memory for the work list
+    work_list = malloc(ip_interface_count[ip_type] * sizeof(dest_filter_list_t *));
+    if (work_list == NULL)
+    {
+        fatal("Cannot allocate memory: %s\n", strerror(errno));
+    }
     for (index = 0; index < ip_interface_count[ip_type]; index++)
     {
-        interface = ip_interface_list[ip_type][index];
-
-        // Allocate the peer list
-        interface->peer_list[ip_type] = calloc(ip_interface_count[ip_type] - 1, sizeof(interface_t *));
-        if (interface->peer_list[ip_type] == NULL)
+        work_list[index] = malloc(ip_interface_count[ip_type] * sizeof(dest_filter_list_t));
+        if (work_list[index] == NULL)
         {
             fatal("Cannot allocate memory: %s\n", strerror(errno));
         }
+    }
 
-        // Allocate the peer outbound filter list if used
-        if (unique_outbound_filter_count)
-        {
-            interface->peer_filter_list[ip_type] = calloc(unique_outbound_filter_count, sizeof(filter_list_t *));
-            if (interface->peer_filter_list[ip_type] == NULL)
-            {
-                fatal("Cannot allocate memory: %s\n", strerror(errno));
-            }
-        }
+    for (interface_index = 0; interface_index < ip_interface_count[ip_type]; interface_index++)
+    {
+        interface = ip_interface_list[ip_type][interface_index];
+
+        // Clear the work list
+        work_list_used = 0;
 
         // Process the peers
         for (peer_index = 0; peer_index < ip_interface_count[ip_type]; peer_index++)
@@ -191,35 +214,87 @@ static void build_interface_peer_lists(
                 continue;
             }
 
-            // Add the peer to the list
-            interface->peer_list[ip_type][interface->peer_count[ip_type]] = peer;
-            interface->peer_count[ip_type] += 1;
+            // Get the filter list used by the peer for this interface
+            filter_list = get_filter_list_for_peer(peer, interface);
 
-            // Check if the peer has outbound filtering
-            if (peer->outbound_filter_list)
+            // Is the filter already in the list?
+            for (index = 0; index < work_list_used; index++)
             {
-                // Is the filter already in the list?
-                for (filter_index = 0; filter_index < interface->peer_filter_count[ip_type]; filter_index++)
+                if (work_list[index]->filter == filter_list)
                 {
-                    if (peer->outbound_filter_list == interface->peer_filter_list[ip_type][filter_index])
+                    break;
+                }
+            }
+
+            // Add the filter to the list if it's not already present
+            if (index >= work_list_used)
+            {
+                work_list_slot = work_list[work_list_used];
+                work_list_used++;
+
+                // Add the filter to the list
+                work_list_slot->filter = filter_list;
+                work_list_slot->peer_list[0] = peer;
+                work_list_slot->peer_count = 1;
+
+                // Check for other peers
+                for (index = peer_index + 1; index < ip_interface_count[ip_type]; index++)
+                {
+                    peer = ip_interface_list[ip_type][index];
+                    if (peer == interface)
                     {
-                        break;
+                        // Skip the current interface
+                        continue;
+                    }
+
+                    // Check the filter list used by the peer for this interface
+                    filter_list = get_filter_list_for_peer(peer, interface);
+                    if (filter_list == work_list_slot->filter)
+                    {
+                        work_list_slot->peer_list[work_list_slot->peer_count] = peer;
+                        work_list_slot->peer_count++;
                     }
                 }
-
-                // If the filter is not in the list, add it
-                if (filter_index == interface->peer_filter_count[ip_type])
-                {
-                    interface->peer_filter_list[ip_type][filter_index] = peer->outbound_filter_list;
-                    interface->peer_filter_count[ip_type] += 1;
-                }
-            }
-            else
-            {
-                interface->peer_nofilter_count[ip_type] += 1;
             }
         }
+
+        // Create the the permanent peer filter list array
+        interface->dest_filter_count[ip_type] = work_list_used;
+        interface->dest_filter_list[ip_type] = malloc(work_list_used * sizeof(dest_filter_list_t *));
+        if (work_list == NULL)
+        {
+            fatal("Cannot allocate memory: %s\n", strerror(errno));
+        }
+
+        // Save each peer filter list
+        for (index = 0; index < work_list_used; index++)
+        {
+            // Allocate memory for the peer filter list
+            dest_filter_list = malloc(sizeof(dest_filter_list_t) + work_list_slot->peer_count * sizeof(struct interface *));
+            if (dest_filter_list == NULL)
+            {
+                fatal("Cannot allocate memory: %s\n", strerror(errno));
+            }
+            interface->dest_filter_list[ip_type][index] = dest_filter_list;
+
+            // Copy the filter and peer list from the work list slot
+            work_list_slot = work_list[index];
+            dest_filter_list->filter = work_list_slot->filter;
+            dest_filter_list->peer_count = work_list_slot->peer_count;
+            for (peer_index = 0; peer_index < work_list_slot->peer_count; peer_index++)
+            {
+                dest_filter_list->peer_list[peer_index] = work_list_slot->peer_list[peer_index];
+            }
+
+        }
     }
+
+    // Clean up the work list
+    for (index = 0; index < ip_interface_count[ip_type]; index++)
+    {
+        free(work_list[index]);
+    }
+    free(work_list);
 }
 
 
@@ -247,10 +322,10 @@ void set_ip_interface_lists(void)
     // Build the peer lists for each interface
     if (ip_interface_count[IPV4])
     {
-        build_interface_peer_lists(IPV4);
+        build_interface_dest_lists(IPV4);
     }
     if (ip_interface_count[IPV6])
     {
-        build_interface_peer_lists(IPV6);
+        build_interface_dest_lists(IPV6);
     }
 }

--- a/mdns-bridge.conf.example
+++ b/mdns-bridge.conf.example
@@ -74,10 +74,19 @@
   # Optionally Disable ipv6.
   #disable-ipv6 = no
 
+  # An optional filter list to deny all inbound packets from this interface
+  #deny-inbound-filters = <all>
+
+  # An optional filter list to deny all outbound packets on this interface
+  #deny-outbound-filters = <all>
+
 [igc1]
   # Optionally Disable ipv6.
   #disable-ipv6 = yes
 
-# An optional list of filters to allow outbound for packets from a specific peers
-  #peer-allow-outbound-filters = igc0, _ipp, _ipps
-  #peer-deny-outbound-filters = igc1, _airplay
+  # An optional list of filters to allow or deny outbound for packets from specific peers
+  #peer-allow-outbound-filters = ix0, _ipp, _ipps
+  #peer-deny-outbound-filters = igc0, _airplay
+
+  # An optional filter list to deny all packets from another interface
+  #peer-deny-outbound-filters = ix0, <all>

--- a/mdns-bridge.conf.example
+++ b/mdns-bridge.conf.example
@@ -77,3 +77,7 @@
 [igc1]
   # Optionally Disable ipv6.
   #disable-ipv6 = yes
+
+# An optional list of filters to allow outbound for packets from a specific peers
+  #peer-allow-outbound-filters = igc0, _ipp, _ipps
+  #peer-deny-outbound-filters = igc1, _airplay

--- a/socket.c
+++ b/socket.c
@@ -35,10 +35,9 @@
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <arpa/inet.h>
-#include <sys/socket.h>
 
 #include "common.h"
-
+#include "socketp.h"
 
 // Multicast addresses (224.0.0.251 and ff02::fb) in hex
 #define IPV4_HEX_MCAST_ADDRESS  0xe00000fb
@@ -288,18 +287,26 @@ static void os_bind_ipv4socket(
     }
 
     // Set interface specific binding if available
-#if defined(SO_BINDTODEVICE)
+#if defined(HAVE_SO_BINDTODEVICE)
     r = setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, interface->name, strlen(interface->name) + 1);
     if (r == -1)
     {
         fatal("setsockopt (SO_BINDTODEVICE) for IPv4 on %s failed: %s\n", interface->name, strerror(errno));
     }
-#elif defined(IP_BOUND_IF)
+#elif defined(HAVE_IP_BOUND_IF)
     r = setsockopt(sock, IPPROTO_IP, IP_BOUND_IF, &interface->if_index, sizeof(interface->if_index));
     if (r == -1)
     {
         fatal("setsockopt (IP_BOUND_IF) for IPv4 on %s failed: %s\n", interface->name, strerror(errno));
     }
+#elif defined(HAVE_IP_RECVIF)
+    r = setsockopt(sock, IPPROTO_IP, IP_RECVIF, &interface->if_index, sizeof(interface->if_index));
+    if (r == -1)
+    {
+        fatal("setsockopt (IP_RECVIF) for IPv4 on %s failed: %s\n", interface->name, strerror(errno));
+    }
+#else
+# error Missing method to set or determine the inbound interface
 #endif
 
     // Set the ttl
@@ -391,18 +398,26 @@ static void os_bind_ipv6socket(
     }
 
     // Set interface specific binding if available
-#if defined(SO_BINDTODEVICE)
+#if defined(HAVE_SO_BINDTODEVICE)
     r = setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, interface->name, strlen(interface->name) + 1);
     if (r == -1)
     {
         fatal("setsockopt (SO_BINDTODEVICE) for IPv6 on %s failed: %s\n", interface->name, strerror(errno));
     }
-#elif defined(IPV6_BOUND_IF)
+#elif defined(HAVE_IPV6_BOUND_IF)
     r = setsockopt(sock, IPPROTO_IPV6, IPV6_BOUND_IF, &interface->if_index, sizeof(interface->if_index));
     if (r == -1)
     {
         fatal("setsockopt (IPV6_BOUND_IF) for IPv6 on %s failed: %s\n", interface->name, strerror(errno));
     }
+#elif defined(HAVE_IP_RECVIF)
+    r = setsockopt(sock, IPPROTO_IPV6, IP_RECVIF, &interface->if_index, sizeof(interface->if_index));
+    if (r == -1)
+    {
+        fatal("setsockopt (IP_RECVIF) for IPv6 on %s failed: %s\n", interface->name, strerror(errno));
+    }
+#else
+#  error Missing method to set or determine the inbound interface
 #endif
 
     // Set the ttl

--- a/socket.c
+++ b/socket.c
@@ -411,6 +411,7 @@ static void os_bind_ipv6socket(
         fatal("setsockopt (IPV6_BOUND_IF) for IPv6 on %s failed: %s\n", interface->name, strerror(errno));
     }
 #elif defined(HAVE_IP_RECVIF)
+    // NB: Yes, it's supposed to be IP_RECVIF, not IPV6_RECVIF
     r = setsockopt(sock, IPPROTO_IPV6, IP_RECVIF, &interface->if_index, sizeof(interface->if_index));
     if (r == -1)
     {

--- a/socket.c
+++ b/socket.c
@@ -404,7 +404,7 @@ static void os_bind_ipv6socket(
     {
         fatal("setsockopt (SO_BINDTODEVICE) for IPv6 on %s failed: %s\n", interface->name, strerror(errno));
     }
-#elif defined(HAVE_IPV6_BOUND_IF)
+#elif defined(HAVE_IP_BOUND_IF)
     r = setsockopt(sock, IPPROTO_IPV6, IPV6_BOUND_IF, &interface->if_index, sizeof(interface->if_index));
     if (r == -1)
     {

--- a/socketp.h
+++ b/socketp.h
@@ -37,13 +37,13 @@
 // Method to set or determine the inbound interface
 #if defined(SO_BINDTODEVICE)
 # define HAVE_SO_BINDTODEVICE
-#elif defined(IPV6_BOUND_IF)
-# define HAVE_IPV6_BOUND_IF
+#elif defined(IP_BOUND_IF)
+# define HAVE_IP_BOUND_IF
 #elif defined(IP_RECVIF)
 # define HAVE_IP_RECVIF
 # include <net/if_dl.h>
 #else
-# error One of SO_BINDTODEVICE, IPV6_BOUND_IF or IP_RECVIF is required
+# error One of SO_BINDTODEVICE, IP_BOUND_IF or IP_RECVIF is required
 #endif
 
 #endif // _SOCKETP_H

--- a/socketp.h
+++ b/socketp.h
@@ -1,0 +1,44 @@
+
+//
+// Copyright (c) 2024-2026, Denny Page
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+#include <sys/socket.h>
+
+
+// Method to set or determine the inbound interface
+#if defined(SO_BINDTODEVICE)
+# define HAVE_SO_BINDTODEVICE
+#elif defined(IPV6_BOUND_IF)
+# define HAVE_IPV6_BOUND_IF
+#elif defined(IP_RECVIF)
+# define HAVE_IP_RECVIF
+# include <net/if_dl.h>
+#else
+# error One of SO_BINDTODEVICE, IPV6_BOUND_IF or IP_RECVIF is required
+#endif

--- a/socketp.h
+++ b/socketp.h
@@ -28,6 +28,9 @@
 //
 
 
+#ifndef _SOCKETP_H
+#define _SOCKETP_H 1
+
 #include <sys/socket.h>
 
 
@@ -42,3 +45,5 @@
 #else
 # error One of SO_BINDTODEVICE, IPV6_BOUND_IF or IP_RECVIF is required
 #endif
+
+#endif // _SOCKETP_H


### PR DESCRIPTION
Add support for peer specific filter lists.
Add support for an efficient deny all filter list.
Switch to using recvmsg() rather than recvfrom().
Use IP_RECVIF to determine the correct interface on BSD systems.
Improve format of filters in the configuration dump.
List all sources and destinations in the configuration dump.
